### PR TITLE
Added disconnect method to the directive

### DIFF
--- a/src/ng-socket-io.js
+++ b/src/ng-socket-io.js
@@ -87,6 +87,9 @@ angular.module('socket-io', []).factory('socket', function($rootScope, io) {
             else {
                 socket.emit(name, data);
             }
+        },
+        disconnect: function(){
+            socket.disconnect();
         }
     };
 

--- a/test/ng-socket-io.spec.js
+++ b/test/ng-socket-io.spec.js
@@ -7,7 +7,7 @@ describe('socket-io module', function() {
     beforeEach(function() {
         module('socket-io');
 
-        socket = jasmine.createSpyObj('socket', ['on', 'once', 'removeListener', 'removeAllListeners', 'emit']);
+        socket = jasmine.createSpyObj('socket', ['on', 'once', 'removeListener', 'removeAllListeners', 'emit', 'disconnect']);
         socket.on.andCallFake(function(name, callback) { currentCallback = callback; });
         socket.once = socket.on;
         socket.emit.andCallFake(function(name, data, callback) { currentCallback = callback; });
@@ -161,6 +161,17 @@ describe('socket-io module', function() {
             expect(callback).toHaveBeenCalledWith('some other data');
             expect($rootScope.$digest).toHaveBeenCalled();
         });
+    });
+    
+    describe('disconnect method', function(){
+        it('calls the dissconnect method', function(){
+            //Act
+        sut.disconnect();
+        
+        //Assert
+        expect(socket.disconnect).toHaveBeenCalled();
+        });
+        
     });
 });
 


### PR DESCRIPTION
Hi,

Added a disconnect method because I noticed that in my Angular app when I have a controller that uses a socket, upon navigating to a different route, the socket is still alive and well on the controller (that should have been destroyed?).

Hence I added a disconnect method to the socket that I can call on the destroy event of my controller to disconnect the socket properly.

Test for the disconnect included.
Cheers!
