### PR TITLE
Added bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,37 @@
+{
+  "name": "ng-socket-io",
+  "version": "0.2.0",
+  "homepage": "https://github.com/mbenford/ngSocketIO",
+  "authors": [
+    "mbenford <michael@michaelbenford.net>"
+  ],
+  "description": "Socket.IO module for AngularJS",
+  "main": "build",
+  "moduleType": [
+    "globals"
+  ],
+  "keywords": [
+    "angular",
+    "angularjs",
+    "socket.io",
+    "websockets"
+  ],
+  "license": "MIT",
+  "private": true,
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "src",
+    "Gruntfile.js",
+    "package.json"
+  ],
+  "dependencies": {
+    "angular": ">=1.0.5"
+  },
+  "devDependencies": {
+    "angular-mocks": ">=1.2.0"
+  },
+  "testPath": "test"
+}


### PR DESCRIPTION
Tested install locally including running with [generator-angular-fullstack](https://github.com/DaftMonk/generator-angular-fullstack) so the file is added to `bower_components` scripts in `index.html` and it works (_adds minified version_).

Did not publish to bower registry and this version has `private` set to `true` per your discretion.

To test local install:
1. Clone repo to local
2. `npm install` to get Grunt for build
3. `grunt build` to generate `build` folder with both full and minified files
4. Navigate to the folder with desired project
5. run `bower install ng-socket-io ~/path/to/ng-socket-io/location/bower.json`
